### PR TITLE
Remove unused dart:async import

### DIFF
--- a/lib/src/qr_painter.dart
+++ b/lib/src/qr_painter.dart
@@ -4,7 +4,6 @@
  * See LICENSE for distribution and usage details.
  */
 
-import 'dart:async';
 import 'dart:typed_data';
 import 'dart:ui' as ui;
 


### PR DESCRIPTION
Since Dart 2.1, Future and Stream have been exported from dart:core