### PR TITLE
Rounded Image Center

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,8 @@ Depending on your data requirements you may want to tweak the QR code output. Th
 | `embeddedImageStyle` | QrEmbeddedImageStyle | Properties to style the embedded image. |
 | `embeddedImageEmitsError` | bool | If true, any failure to load the embedded image will trigger the `errorStateBuilder` or render an empty `Container`. If false, the QR code will be rendered and the embedded image will be ignored. |
 |`semanticsLabel`|String|`semanticsLabel` will be used by screen readers to describe the content of the QR code.|
+|`roundedImage`| bool | If true, image shows as a circular image with stock in the QR code.|
+|`borderColor`| Color | The rounded image stock color in the QR code.|
 
 # Examples
 
@@ -110,6 +112,23 @@ QrImage(
   embeddedImageStyle: QrEmbeddedImageStyle(
     size: Size(80, 80),
   ),
+)
+```
+
+A QR code with an rounded image (from your application's assets) will look like:
+
+```dart
+QrImage(
+  data: 'This QR code has an embedded image as well',
+  version: QrVersions.auto,
+  size: 320,
+  gapless: false,
+  embeddedImage: AssetImage('assets/images/my_embedded_image.png'),
+  embeddedImageStyle: QrEmbeddedImageStyle(
+    size: Size(80, 80),
+  ),
+  roundedImage: true,
+  borderColor: Colors.green,
 )
 ```
 

--- a/lib/src/qr_image.dart
+++ b/lib/src/qr_image.dart
@@ -46,6 +46,8 @@ class QrImage extends StatefulWidget {
       color: Colors.black,
     ),
     this.embeddedImageEmitsError = false,
+    this.roundedImage = false,
+    this.borderColor = Colors.white,
   })  : assert(QrVersions.isSupportedVersion(version)),
         _data = data,
         _qrCode = null,
@@ -77,6 +79,8 @@ class QrImage extends StatefulWidget {
       color: Colors.black,
     ),
     this.embeddedImageEmitsError = false,
+    this.roundedImage = false,
+    this.borderColor = Colors.white,
   })  : assert(QrVersions.isSupportedVersion(version)),
         _data = null,
         _qrCode = qr,
@@ -84,6 +88,7 @@ class QrImage extends StatefulWidget {
 
   // The data passed to the widget
   final String? _data;
+
   // The QR code data passed to the widget
   final QrCode? _qrCode;
 
@@ -147,6 +152,13 @@ class QrImage extends StatefulWidget {
 
   /// Styling option for QR data module.
   final QrDataModuleStyle dataModuleStyle;
+
+  /// Rounded image option in the QR code. The image will
+  /// be added to the center of the QR code.
+  final bool roundedImage;
+
+  /// Rounded image option circular border color in the QR code.
+  final Color borderColor;
 
   @override
   _QrImageState createState() => _QrImageState();
@@ -215,14 +227,15 @@ class _QrImageState extends State<QrImage> {
 
   Widget _qrWidget(BuildContext context, ui.Image? image, double edgeLength) {
     final painter = QrPainter.withQr(
-      qr: _qr!,
-      color: widget.foregroundColor,
-      gapless: widget.gapless,
-      embeddedImageStyle: widget.embeddedImageStyle,
-      embeddedImage: image,
-      eyeStyle: widget.eyeStyle,
-      dataModuleStyle: widget.dataModuleStyle,
-    );
+        qr: _qr!,
+        color: widget.foregroundColor,
+        gapless: widget.gapless,
+        embeddedImageStyle: widget.embeddedImageStyle,
+        embeddedImage: image,
+        eyeStyle: widget.eyeStyle,
+        dataModuleStyle: widget.dataModuleStyle,
+        roundedImage: widget.roundedImage,
+        borderColor: widget.borderColor);
     return _QrContentView(
       edgeLength: edgeLength,
       backgroundColor: widget.backgroundColor,
@@ -250,6 +263,7 @@ class _QrImageState extends State<QrImage> {
   }
 
   late ImageStreamListener streamListener;
+
   Future<ui.Image> _loadQrImage(
       BuildContext buildContext, QrEmbeddedImageStyle? style) async {
     if (style != null) {}


### PR DESCRIPTION
We have implemented a feature to have a rounded image in the center instead of a square image. 

There are two options for the end user

roundedImage = false,
borderColor = Colors.white

Rounded Image as a boolean value having default value of false. 
Border color for showing a distinction between image and qr code lines.

Border color is only applicable incase of roundedImage is set to true.