### PR TITLE
Fix GitHub link for pubspec.yaml

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ dependencies:
 dependencies:
   qr_flutter:
     git:
-      url: git://github.com/lukef/qr.flutter.git
+      url: git@github.com:theyakka/qr.flutter.git
 ```
 
 Keep in mind the `master` branch could be unstable.


### PR DESCRIPTION
Just a little fix, as at least my Android Studio did not follow the redirect from ~/lukef/qr.flutter.git to ~/qr.flutter.git