### PR TITLE
[Android] Remove deprecated splash screen meta-data element

### DIFF
--- a/example/android/app/src/main/AndroidManifest.xml
+++ b/example/android/app/src/main/AndroidManifest.xml
@@ -20,9 +20,6 @@
             android:hardwareAccelerated="true"
             android:windowSoftInputMode="adjustResize">
             <meta-data
-                android:name="io.flutter.embedding.android.SplashScreenDrawable"
-                android:resource="@drawable/launch_background" />
-            <meta-data
                 android:name="io.flutter.embedding.android.NormalTheme"
                 android:resource="@style/NormalTheme"
                 />


### PR DESCRIPTION
Deletes deprecated splash screen meta-data element in example app.

This is no longer needed to present a splash screen in a Flutter application, but may cause a crash. Please see [Deprecated Splash Screen API Migration Guide](https://docs.flutter.dev/development/platform-integration/android/splash-screen-migration) for more information.